### PR TITLE
Fix required region prompts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,9 @@ provider "aws" {
   region = "${var.region}"
 }
 
+# Get the access to the effective Account ID, User ID, and ARN in which Terraform is authorized.
+data "aws_caller_identity" "current" {}
+
 # Provides an IAM role.
 resource "aws_iam_role" "this" {
   name        = "${var.role_name}"

--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,8 @@ provider "aws" {
   version = "~> 1.14"
 
   # region is added to prevent consumers getting region prompts (one prompt for each usage)
-  region = "${data.aws_region.current.name}"
+  region = "${var.region}"
 }
-
-# Get the access to the effective Account ID, User ID, and ARN in which Terraform is authorized.
-data "aws_caller_identity" "current" {}
 
 # Provides an IAM role.
 resource "aws_iam_role" "this" {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,9 @@
 # Added provider AWS version constraint. `max_session_duration` is supported on 1.14.0
 provider "aws" {
   version = "~> 1.14"
-  region  = "ap-southeast-1"
+
+  # region is added to prevent consumers getting region prompts (one prompt for each usage)
+  region = "${data.aws_region.current.name}"
 }
 
 # Get the access to the effective Account ID, User ID, and ARN in which Terraform is authorized.

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 # Added provider AWS version constraint. `max_session_duration` is supported on 1.14.0
 provider "aws" {
   version = "~> 1.14"
+  region  = "ap-southeast-1"
 }
 
 # Get the access to the effective Account ID, User ID, and ARN in which Terraform is authorized.

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "region" {
+  description = "The region from which this module will be executed"
+  type        = "string"
+  default     = "ap-southeast-1"
+}
+
 variable "role_name" {
   description = "The name of the role. It will forces new resource on change."
   type        = "string"


### PR DESCRIPTION
should fix #8

## Test Case
Apply this configuration
```
provider "aws" {
  region = "ap-southeast-1"
}
module "codebuild-bake-ami" {
  source = "github.com/salvianreynaldi/terraform-aws-iam-role.git//modules/service?ref=fix%2Fremove-region-prompt"

  role_identifier            = "CodeBuild Bake AMI"
  role_description           = "Service Role for CodeBuild Bake AMI"
  role_force_detach_policies = true
  role_max_session_duration  = 43200

  aws_service = "codebuild.amazonaws.com"
}

module "codepipeline-bake-ami" {
  source = "github.com/salvianreynaldi/terraform-aws-iam-role.git//modules/service?ref=fix%2Fremove-region-prompt"

  role_identifier            = "CodePipeline Bake AMI"
  role_description           = "Service Role for CodePipeline Bake AMI"
  role_force_detach_policies = true
  role_max_session_duration  = 43200

  aws_service = "codepipeline.amazonaws.com"
}

module "template" {
  source = "github.com/salvianreynaldi/terraform-aws-iam-role.git//modules/instance?ref=fix%2Fremove-region-prompt"

  service_name = "${var.service-name}"
  cluster_role = "template"
}
```
it should not prompt for `region` 3 times


Plus, I think the default region value doesn't really matter as the created IAM Roles are global