### PR TITLE
relax provider versions for terraform 0.12 readiness

### DIFF
--- a/modules/external/main.tf
+++ b/modules/external/main.tf
@@ -1,5 +1,5 @@
 provider "null" {
-  version = ">= 1.0.0"
+  version = "~> 1.0.0"
 }
 
 # Work around to throws an exception. 

--- a/modules/external/main.tf
+++ b/modules/external/main.tf
@@ -1,5 +1,5 @@
 provider "null" {
-  version = "~> 1.0.0"
+  version = ">= 1.0.0, < 3.0.0"
 }
 
 # Work around to throws an exception. 

--- a/modules/external/main.tf
+++ b/modules/external/main.tf
@@ -1,5 +1,5 @@
 provider "null" {
-  version = "1.0.0"
+  version = ">= 1.0.0"
 }
 
 # Work around to throws an exception. 

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -1,5 +1,5 @@
 provider "random" {
-  version = ">= 1.2.0"
+  version = "~> 1.2.0"
 }
 
 # Contains local values that are used to increase DRYness of the code.

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -1,5 +1,5 @@
 provider "random" {
-  version = "1.2.0"
+  version = ">= 1.2.0"
 }
 
 # Contains local values that are used to increase DRYness of the code.

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -1,5 +1,5 @@
 provider "random" {
-  version = "~> 1.2.0"
+  version = ">= 1.2.0, < 3.0.0"
 }
 
 # Contains local values that are used to increase DRYness of the code.

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1,5 +1,5 @@
 provider "random" {
-  version = ">= 1.2.0"
+  version = "~> 1.2.0"
 }
 
 # Contains local values that are used to increase DRYness of the code.

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1,5 +1,5 @@
 provider "random" {
-  version = "1.2.0"
+  version = ">= 1.2.0"
 }
 
 # Contains local values that are used to increase DRYness of the code.

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -1,5 +1,5 @@
 provider "random" {
-  version = "~> 1.2.0"
+  version = ">= 1.2.0, < 3.0.0"
 }
 
 # Contains local values that are used to increase DRYness of the code.


### PR DESCRIPTION
If provider versions are fixed inside modules, parent terraform scripts cannot specify a different version as it will cause version conflicts.

Instead of removing provider versions all together, it might be beneficial to relax the versioning from a strict version to a greater than version. This hopefully sends the message that this modules will work with a provider version of the at least specified version.

Context:
I'm trying to prepare my terraform to be 0.12 ready and they recommend that I upgrade some providers. However I cannot upgrade them since their versions are fixed in this child module.