### PR TITLE
Simplify policies attachment

### DIFF
--- a/examples/instance-profile/main.tf
+++ b/examples/instance-profile/main.tf
@@ -11,9 +11,8 @@ module "this" {
   cluster_role   = "app"
   product_domain = "txt"
   environment    = "production"
-}
 
-resource "aws_iam_role_policy_attachment" "this" {
-  role       = "${module.this.role_name}"
-  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  role_policy_attachments = [
+    "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+  ]
 }

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -54,6 +54,14 @@ module "this" {
   environment    = "${var.environment}"
 }
 
+# Attaches policies
+resource "aws_iam_role_policy_attachment" "this" {
+  count = "${length(var.role_policy_attachments)}"
+
+  role       = "${module.this.role_name}"
+  policy_arn = "${element(var.role_policy_attachments, count.index)}"
+}
+
 # Provides an IAM instance profile.
 resource "aws_iam_instance_profile" "this" {
   name = "${replace(random_id.role_name.hex, "Role", "Profile")}"

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -33,3 +33,9 @@ variable "role_tags" {
   type        = "map"
   default     = {}
 }
+
+variable "role_policy_attachments" {
+  description = "Policies to attach to the role"
+  type = "list"
+  default = []
+}


### PR DESCRIPTION
`$ terraform plan`

Before
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + module.this.aws_iam_instance_profile.this
      id:                    <computed>
      arn:                   <computed>
      create_date:           <computed>
      name:                  "${replace(random_id.role_name.hex, \"Role\", \"Profile\")}"
      path:                  "/instance-profile/"
      role:                  "${module.this.role_name}"
      roles.#:               <computed>
      unique_id:             <computed>

  + aws_iam_role_policy_attachment.this
      id:                    <computed>
      policy_arn:            "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
      role:                  "${module.this.role_name}"

  + module.this.random_id.role_name
      id:                    <computed>
      b64:                   <computed>
      b64_std:               <computed>
      b64_url:               <computed>
      byte_length:           "8"
      dec:                   <computed>
      hex:                   <computed>
      prefix:                "InstanceRole_txtdata-app-"

  + module.this.module.this.aws_iam_role.this
      id:                    <computed>
      arn:                   <computed>
      assume_role_policy:    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"ec2.amazonaws.com\"\n      }\n    }\n  ]\n}"
      create_date:           <computed>
      description:           "Instance Role for txtdata-app"
      force_detach_policies: "false"
      max_session_duration:  "3600"
      name:                  "${var.role_name}"
      path:                  "/instance-role/"
      tags.%:                <computed>
      unique_id:             <computed>


Plan: 4 to add, 0 to change, 0 to destroy.
```

After
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + module.this.aws_iam_instance_profile.this
      id:                    <computed>
      arn:                   <computed>
      create_date:           <computed>
      name:                  "${replace(random_id.role_name.hex, \"Role\", \"Profile\")}"
      path:                  "/instance-profile/"
      role:                  "${module.this.role_name}"
      roles.#:               <computed>
      unique_id:             <computed>

  + module.this.aws_iam_role_policy_attachment.this
      id:                    <computed>
      policy_arn:            "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
      role:                  "${module.this.role_name}"

  + module.this.random_id.role_name
      id:                    <computed>
      b64:                   <computed>
      b64_std:               <computed>
      b64_url:               <computed>
      byte_length:           "8"
      dec:                   <computed>
      hex:                   <computed>
      prefix:                "InstanceRole_txtdata-app-"

  + module.this.module.this.aws_iam_role.this
      id:                    <computed>
      arn:                   <computed>
      assume_role_policy:    "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": \"sts:AssumeRole\",\n      \"Principal\": {\n        \"Service\": \"ec2.amazonaws.com\"\n      }\n    }\n  ]\n}"
      create_date:           <computed>
      description:           "Instance Role for txtdata-app"
      force_detach_policies: "false"
      max_session_duration:  "3600"
      name:                  "${var.role_name}"
      path:                  "/instance-role/"
      tags.%:                <computed>
      unique_id:             <computed>


Plan: 4 to add, 0 to change, 0 to destroy.
```