### PR TITLE
make role name and path 64 chars or less. while putting the information into tags

### DIFF
--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -7,12 +7,19 @@ locals {
   # max bytes of random id to use as unique suffix. 16 hex chars, each byte takes 2 hex chars
   max_byte_length = 8
 
-  # Example value: "ServiceRoleForConfig_default-config-dec5ac0e50847943"
-  role_name_max_length      = 64
-  role_name_format          = "ServiceRoleFor%s_%s-"
+  # Example value: "ServiceRole_Config_default-config-dec5ac0e50847943"
+  # since path is always 1, to support Role Switching, maximum length of name can only be 63
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html#reference_iam-limits-entity-length
+  role_name_max_length      = 63
+  role_name_format          = "ServiceRole_%s_%s-"
   role_name_prefix          = "${format(local.role_name_format, title(element(split(".", var.aws_service), 0)),join("-", split(" ", lower(var.role_identifier))))}"
   role_name_max_byte_length = "${(local.role_name_max_length - length(local.role_name_prefix)) / 2}"
   role_name_byte_length     = "${min(local.max_byte_length, local.role_name_max_byte_length)}"
+
+  role_tags = "${merge(var.role_tags, map(
+    "Type", "service-role",
+    "Service", "var.aws_service"
+     ))}"
 }
 
 # Trust relationship policy document for AWS Service.
@@ -38,9 +45,9 @@ module "this" {
   source = "../../"
 
   role_name        = "${random_id.role_name.hex}"
-  role_path        = "/service-role/${var.aws_service}/"
+  role_path        = "/"
   role_description = "${var.role_description}"
-  role_tags        = "${var.role_tags}"
+  role_tags        = "${local.role_tags}"
 
   role_assume_policy         = "${data.aws_iam_policy_document.this.json}"
   role_force_detach_policies = "${var.role_force_detach_policies}"


### PR DESCRIPTION
Fixes https://github.com/traveloka/terraform-aws-iam-role/issues/28 for service roles. 

I'm only able to test the service roles as I am using them in https://github.com/traveloka/terraform-aws-codebuild-terraform-ci-cd

