### PR TITLE
bug/aws_iam_policy_document.principals.identifier should be a list

### DIFF
--- a/modules/crossaccount/main.tf
+++ b/modules/crossaccount/main.tf
@@ -4,7 +4,7 @@ data "aws_iam_policy_document" "doc" {
 
     principals = {
       type        = "AWS"
-      identifiers = "${var.trusted_role_arns}"
+      identifiers = ["${var.trusted_role_arns}"]
     }
   }
 }

--- a/modules/user/main.tf
+++ b/modules/user/main.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "with_mfa" {
 
     principals = {
       type        = "AWS"
-      identifiers = "${var.trusted_users}"
+      identifiers = ["${var.trusted_users}"]
     }
 
     condition = [
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "without_mfa" {
 
     principals = {
       type        = "AWS"
-      identifiers = "${var.trusted_users}"
+      identifiers = ["${var.trusted_users}"]
     }
   }
 }


### PR DESCRIPTION
All other modules already specify it as a list.
Only these 2 modules are still using the old syntax.