### PR TITLE
Add permission_boundary variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ resource "aws_iam_role" "this" {
   description = "${var.role_description}"
 
   assume_role_policy    = "${var.role_assume_policy}"
+  permissions_boundary  = "${var.role_permission_boundary}"
   force_detach_policies = "${var.role_force_detach_policies}"
   max_session_duration  = "${var.role_max_session_duration}"
 

--- a/modules/crossaccount/main.tf
+++ b/modules/crossaccount/main.tf
@@ -32,6 +32,7 @@ module "crossacount" {
     ))}"
 
   role_assume_policy         = "${data.aws_iam_policy_document.doc.json}"
+  role_permission_boundary   = "${var.role_permission_boundary}"
   role_force_detach_policies = "${var.role_force_detach_policies}"
   role_max_session_duration  = "${var.role_max_session_duration}"
 

--- a/modules/crossaccount/variables.tf
+++ b/modules/crossaccount/variables.tf
@@ -29,6 +29,12 @@ variable "role_max_session_duration" {
   default     = 3600
 }
 
+variable "role_permission_boundary" {
+  description = "IAM policy ARN limiting the maximum access this role can have"
+  type        = "string"
+  default     = ""
+}
+
 variable "product_domain" {
   description = "Abbreviation of the product domain the created resources belong to"
   type        = "string"

--- a/modules/external/main.tf
+++ b/modules/external/main.tf
@@ -41,6 +41,7 @@ module "this" {
   role_tags        = "${var.role_tags}"
 
   role_assume_policy         = "${data.aws_iam_policy_document.doc.json}"
+  role_permission_boundary   = "${var.role_permission_boundary}}"
   role_force_detach_policies = "${var.role_force_detach_policies}"
   role_max_session_duration  = "${var.role_max_session_duration}"
 

--- a/modules/external/variables.tf
+++ b/modules/external/variables.tf
@@ -34,6 +34,12 @@ variable "role_max_session_duration" {
   default     = "3600"
 }
 
+variable "role_permission_boundary" {
+  description = "IAM policy ARN limiting the maximum access this role can have"
+  type        = "string"
+  default     = ""
+}
+
 variable "product_domain" {
   description = "Abbreviation of the product domain the created resources belong to"
   type        = "string"

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -47,6 +47,7 @@ module "this" {
     ))}"
 
   role_assume_policy         = "${data.aws_iam_policy_document.this.json}"
+  role_permission_boundary   = "${var.role_permission_boundary}"
   role_force_detach_policies = "${var.role_force_detach_policies}"
   role_max_session_duration  = "${var.role_max_session_duration}"
 

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -18,6 +18,12 @@ variable "role_max_session_duration" {
   default     = 3600
 }
 
+variable "role_permission_boundary" {
+  description = "IAM policy ARN limiting the maximum access this role can have"
+  type        = "string"
+  default     = ""
+}
+
 variable "product_domain" {
   description = "Abbreviation of the product domain the created resources belong to"
   type        = "string"

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -49,6 +49,7 @@ module "this" {
     ))}"
 
   role_assume_policy         = "${var.lambda_type == true ? data.aws_iam_policy_document.edge.json : data.aws_iam_policy_document.this.json}"
+  role_permission_boundary   = "${var.role_permission_boundary}"
   role_force_detach_policies = "${var.role_force_detach_policies}"
   role_max_session_duration  = "${var.role_max_session_duration}"
 

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -24,6 +24,12 @@ variable "role_max_session_duration" {
   default     = 3600
 }
 
+variable "role_permission_boundary" {
+  description = "IAM policy ARN limiting the maximum access this role can have"
+  type        = "string"
+  default     = ""
+}
+
 variable "lambda_type" {
   description = "type of lambda , if lambda edge this variable should be true"
   default     = false

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -43,6 +43,7 @@ module "this" {
   role_tags        = "${var.role_tags}"
 
   role_assume_policy         = "${data.aws_iam_policy_document.this.json}"
+  role_permission_boundary   = "${var.role_permission_boundary}"
   role_force_detach_policies = "${var.role_force_detach_policies}"
   role_max_session_duration  = "${var.role_max_session_duration}"
 

--- a/modules/service/variables.tf
+++ b/modules/service/variables.tf
@@ -23,6 +23,12 @@ variable "role_max_session_duration" {
   default     = 3600
 }
 
+variable "role_permission_boundary" {
+  description = "IAM policy ARN limiting the maximum access this role can have"
+  type        = "string"
+  default     = ""
+}
+
 variable "product_domain" {
   description = "Abbreviation of the product domain the created resources belong to"
   type        = "string"

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,9 @@ variable "role_max_session_duration" {
   description = "The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours."
   default     = 3600
 }
+
+variable "role_permission_boundary" {
+  description = "IAM policy ARN limiting the maximum access this role can have"
+  type        = "string"
+  default     = ""
+}


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #23. Creating this PR to prevent `PowerUser` escalating privilege while letting `PowerUser` create roles for instances on my multi account

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-iam-role/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:

* feature: Add support for permission_boundary 
```
<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
